### PR TITLE
Added method `refresh()`.

### DIFF
--- a/src/GitRepository.php
+++ b/src/GitRepository.php
@@ -489,6 +489,20 @@
 				->end();
 		}
 
+        /**
+         * Refresh working tree index.
+         * Looks at the current index and checks to see if merges or updates are needed by
+         * checking stat() information. Useful when you want to make sure git all the latest
+         * changes will appear in the git status.
+         * @return self
+         */
+        public function refresh()
+        {
+            return $this->begin()
+                ->run('git update-index -q --refresh')
+                ->end();
+		}
+
 
 		/**
 		 * @return self


### PR DESCRIPTION
Looks at the current index and checks to see if merges or updates are needed by checking stat() information. Useful when you want to make sure git all the latest changes will appear in the git status.