### PR TITLE
Added 'git clean' and improved code comments

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -89,6 +89,9 @@ $repo->removeFile(array('file3.txt', 'file4.txt'));
 
 // adds all changes in repository
 $repo->addAllChanges();
+
+// removes all unstaged files and directories in repository
+$repo->clean();
 ```
 
 

--- a/src/GitRepository.php
+++ b/src/GitRepository.php
@@ -274,6 +274,7 @@
          */
         public function clean($cleanDirectories = true, $force = true)
         {
+            $options = null;
             if (!($cleanDirectories === false && $force === false)) {
                 $options = '-';
                 if ($force) {

--- a/src/IGit.php
+++ b/src/IGit.php
@@ -14,7 +14,7 @@
 		 * Creates a tag.
 		 * @param  string
 		 * @param  array|NULL
-		 * @throws Cz\Git\GitException
+		 * @throws GitException
 		 */
 		function createTag($name, $options = NULL);
 
@@ -22,7 +22,7 @@
 		/**
 		 * Removes tag.
 		 * @param  string
-		 * @throws Cz\Git\GitException
+		 * @throws GitException
 		 */
 		function removeTag($name);
 
@@ -31,7 +31,7 @@
 		 * Renames tag.
 		 * @param  string
 		 * @param  string
-		 * @throws Cz\Git\GitException
+		 * @throws GitException
 		 */
 		function renameTag($oldName, $newName);
 
@@ -47,7 +47,7 @@
 		 * Merges branches.
 		 * @param  string
 		 * @param  array|NULL
-		 * @throws Cz\Git\GitException
+		 * @throws GitException
 		 */
 		function merge($branch, $options = NULL);
 
@@ -56,7 +56,7 @@
 		 * Creates new branch.
 		 * @param  string
 		 * @param  bool
-		 * @throws Cz\Git\GitException
+		 * @throws GitException
 		 */
 		function createBranch($name, $checkout = FALSE);
 
@@ -64,7 +64,7 @@
 		/**
 		 * Removes branch.
 		 * @param  string
-		 * @throws Cz\Git\GitException
+		 * @throws GitException
 		 */
 		function removeBranch($name);
 
@@ -72,7 +72,7 @@
 		/**
 		 * Gets name of current branch
 		 * @return string
-		 * @throws Cz\Git\GitException
+		 * @throws GitException
 		 */
 		function getCurrentBranchName();
 
@@ -94,7 +94,7 @@
 		/**
 		 * Checkout branch.
 		 * @param  string
-		 * @throws Cz\Git\GitException
+		 * @throws GitException
 		 */
 		function checkout($name);
 
@@ -102,7 +102,7 @@
 		/**
 		 * Removes file(s).
 		 * @param  string|string[]
-		 * @throws Cz\Git\GitException
+		 * @throws GitException
 		 */
 		function removeFile($file);
 
@@ -110,14 +110,14 @@
 		/**
 		 * Adds file(s).
 		 * @param  string|string[]
-		 * @throws Cz\Git\GitException
+		 * @throws GitException
 		 */
 		function addFile($file);
 
 
 		/**
 		 * Adds all created, modified & removed files.
-		 * @throws Cz\Git\GitException
+		 * @throws GitException
 		 */
 		function addAllChanges();
 
@@ -126,7 +126,7 @@
 		 * Renames file(s).
 		 * @param  string|string[]  from: array('from' => 'to', ...) || (from, to)
 		 * @param  string|NULL
-		 * @throws Cz\Git\GitException
+		 * @throws GitException
 		 */
 		function renameFile($file, $to = NULL);
 
@@ -135,7 +135,7 @@
 		 * Commits changes
 		 * @param  string
 		 * @param  string[]  param => value
-		 * @throws Cz\Git\GitException
+		 * @throws GitException
 		 */
 		function commit($message, $params = NULL);
 

--- a/tests/GitPhp/basic.phpt
+++ b/tests/GitPhp/basic.phpt
@@ -54,6 +54,16 @@ $repo->commit('Removed second file');
 Assert::false($repo->hasChanges());
 
 
+// clean
+$file = TEMP_DIR . '/somefile.txt';
+$dir = TEMP_DIR . '/somedir';
+file_put_contents($file, "Sit amet dolor ipsum lorem.\n");
+mkdir($dir);
+Assert::true($repo->hasChanges());
+$repo->clean();
+Assert::false($repo->hasChanges());
+
+
 // Branches
 $repo->createBranch('develop', TRUE);
 Assert::same(array(


### PR DESCRIPTION
I added git clean to the repo functionality and fixed the Comments to have them declare the proper exception throwing. As both files are in the same namespace, the thrown error should be either `\Cz\Git\GitException` or just `GitException`, is chose the latter.