### PR TITLE
Fixed GitException inconsistencies in PhpDoc comments

### DIFF
--- a/src/GitRepository.php
+++ b/src/GitRepository.php
@@ -50,7 +50,7 @@
 		 * `git tag <name>`
 		 * @param  string
 		 * @param  array|NULL
-		 * @throws Cz\Git\GitException
+		 * @throws GitException
 		 * @return self
 		 */
 		public function createTag($name, $options = NULL)
@@ -65,7 +65,7 @@
 		 * Removes tag.
 		 * `git tag -d <name>`
 		 * @param  string
-		 * @throws Cz\Git\GitException
+		 * @throws GitException
 		 * @return self
 		 */
 		public function removeTag($name)
@@ -84,7 +84,7 @@
 		 * `git tag -d <old>`
 		 * @param  string
 		 * @param  string
-		 * @throws Cz\Git\GitException
+		 * @throws GitException
 		 * @return self
 		 */
 		public function renameTag($oldName, $newName)
@@ -114,7 +114,7 @@
 		 * `git merge <options> <name>`
 		 * @param  string
 		 * @param  array|NULL
-		 * @throws Cz\Git\GitException
+		 * @throws GitException
 		 * @return self
 		 */
 		public function merge($branch, $options = NULL)
@@ -131,7 +131,7 @@
 		 * (optionaly) `git checkout <name>`
 		 * @param  string
 		 * @param  bool
-		 * @throws Cz\Git\GitException
+		 * @throws GitException
 		 * @return self
 		 */
 		public function createBranch($name, $checkout = FALSE)
@@ -154,7 +154,7 @@
 		 * Removes branch.
 		 * `git branch -d <name>`
 		 * @param  string
-		 * @throws Cz\Git\GitException
+		 * @throws GitException
 		 * @return self
 		 */
 		public function removeBranch($name)
@@ -171,7 +171,7 @@
 		 * Gets name of current branch
 		 * `git branch` + magic
 		 * @return string
-		 * @throws Cz\Git\GitException
+		 * @throws GitException
 		 */
 		public function getCurrentBranchName()
 		{
@@ -224,7 +224,7 @@
 		 * Checkout branch.
 		 * `git checkout <branch>`
 		 * @param  string
-		 * @throws Cz\Git\GitException
+		 * @throws GitException
 		 * @return self
 		 */
 		public function checkout($name)
@@ -239,7 +239,7 @@
 		 * Removes file(s).
 		 * `git rm <file>`
 		 * @param  string|string[]
-		 * @throws Cz\Git\GitException
+		 * @throws GitException
 		 * @return self
 		 */
 		public function removeFile($file)
@@ -264,7 +264,7 @@
 		 * Adds file(s).
 		 * `git add <file>`
 		 * @param  string|string[]
-		 * @throws Cz\Git\GitException
+		 * @throws GitException
 		 * @return self
 		 */
 		public function addFile($file)
@@ -289,7 +289,7 @@
 		/**
 		 * Adds all created, modified & removed files.
 		 * `git add --all`
-		 * @throws Cz\Git\GitException
+		 * @throws GitException
 		 * @return self
 		 */
 		public function addAllChanges()
@@ -305,7 +305,7 @@
 		 * `git mv <file>`
 		 * @param  string|string[]  from: array('from' => 'to', ...) || (from, to)
 		 * @param  string|NULL
-		 * @throws Cz\Git\GitException
+		 * @throws GitException
 		 * @return self
 		 */
 		public function renameFile($file, $to = NULL)
@@ -333,7 +333,7 @@
 		 * `git commit <params> -m <message>`
 		 * @param  string
 		 * @param  string[]  param => value
-		 * @throws Cz\Git\GitException
+		 * @throws GitException
 		 * @return self
 		 */
 		public function commit($message, $params = NULL)
@@ -603,7 +603,7 @@
 		 * Runs command.
 		 * @param  string|array
 		 * @return self
-		 * @throws Cz\Git\GitException
+		 * @throws GitException
 		 */
 		protected function run($cmd/*, $options = NULL*/)
 		{

--- a/src/GitRepository.php
+++ b/src/GitRepository.php
@@ -19,6 +19,7 @@
 
 		/**
 		 * @param  string
+		 * @throws GitException
 		 */
 		public function __construct($repository)
 		{
@@ -102,6 +103,7 @@
 		/**
 		 * Returns list of tags in repo.
 		 * @return string[]|NULL  NULL => no tags
+		 * @throws GitException
 		 */
 		public function getTags()
 		{
@@ -199,6 +201,7 @@
 		/**
 		 * Returns list of all (local & remote) branches in repo.
 		 * @return string[]|NULL  NULL => no branches
+		 * @throws GitException
 		 */
 		public function getBranches()
 		{
@@ -211,6 +214,7 @@
 		/**
 		 * Returns list of local branches in repo.
 		 * @return string[]|NULL  NULL => no branches
+		 * @throws GitException
 		 */
 		public function getLocalBranches()
 		{
@@ -355,6 +359,7 @@
 		 * Exists changes?
 		 * `git status` + magic
 		 * @return bool
+		 * @throws GitException
 		 */
 		public function hasChanges()
 		{
@@ -372,6 +377,7 @@
 
 		/**
 		 * @deprecated
+		 * @throws GitException
 		 */
 		public function isChanges()
 		{
@@ -445,6 +451,7 @@
 		 * @param  string
 		 * @param  array|NULL
 		 * @return self
+		 * @throws GitException
 		 */
 		public function addRemote($name, $url, array $params = NULL)
 		{
@@ -459,6 +466,7 @@
 		 * @param  string
 		 * @param  string
 		 * @return self
+		 * @throws GitException
 		 */
 		public function renameRemote($oldName, $newName)
 		{
@@ -472,6 +480,7 @@
 		 * Removes remote repository
 		 * @param  string
 		 * @return self
+		 * @throws GitException
 		 */
 		public function removeRemote($name)
 		{
@@ -487,6 +496,7 @@
 		 * @param  string
 		 * @param  array|NULL
 		 * @return self
+		 * @throws GitException
 		 */
 		public function setRemoteUrl($name, $url, array $params = NULL)
 		{
@@ -499,6 +509,7 @@
 		/**
 		 * @param  string|string[]
 		 * @return string[]  returns output
+		 * @throws GitException
 		 */
 		public function execute($cmd)
 		{
@@ -556,6 +567,7 @@
 		 * @param  string
 		 * @param  callback|NULL
 		 * @return string[]|NULL
+		 * @throws GitException
 		 */
 		protected function extractFromCommand($cmd, $filter = NULL)
 		{
@@ -697,6 +709,7 @@
 		 * @param  string|NULL
 		 * @param  array|NULL
 		 * @return self
+		 * @throws GitException
 		 */
 		public static function cloneRepository($url, $directory = NULL, array $params = NULL)
 		{


### PR DESCRIPTION
Because PhpStorm was complaining about uncaught exceptions I looked into your code and found that `GitException` was defined with a relative namespace `Cz\Git\GitException` in the PhpDoc comments. Because the whole file is in namespace `Cz\Git`, this resolves to `Cz\Git\Cz\Git\GitException`. I fixed it by removing the relative path.

In the process I also found that some functions were missing the mention of throwing the exception, so I added those too. 

I tried to make the commit messages equal to the style you are using yourself, and made sure I used tabs instead of spaces.