### PR TITLE
Resolve TODO's

### DIFF
--- a/src/GitRepository.php
+++ b/src/GitRepository.php
@@ -264,14 +264,15 @@
 		}
 
 
-		/**
-		 * Adds file(s).
-		 * `git add <file>`
-		 * @param  string|string[]
-		 * @throws GitException
-		 * @return self
-		 */
-		public function addFile($file)
+        /**
+         * Adds file(s).
+         * `git add <file>`
+         * @param  string|string[]
+         * @param bool $prependRoot Whether to prepend the path to the repository (from {@link getRepositoryPath}).
+         * @return self
+         * @throws GitException
+         */
+		public function addFile($file, $prependRoot = true)
 		{
 			if(!is_array($file))
 			{
@@ -282,8 +283,21 @@
 
 			foreach($file as $item)
 			{
-				// TODO: ?? is file($repo . / . $item) ??
-				$this->run('git add', $item);
+			    // make sure the given item exists
+                // this can be a file or an directory, git supports both
+                $path = $prependRoot ?
+                    $this->getRepositoryPath() . DIRECTORY_SEPARATOR . $item :
+                    $item;
+                if (file_exists($path))
+                {
+                    $this->run('git add', $item);
+                }
+                else
+                {
+                    throw new GitException(sprintf(
+                        "The path at '%s' does not represent a valid file!", $item
+                    ));
+                }
 			}
 
 			return $this->end();


### PR DESCRIPTION
The `// TODO` notice on [line 285](https://github.com/czproject/git-php/blob/ebc5b3c48fa44dbcbf1ccb7ffc32baca0960efcc/src/GitRepository.php#L285) was resolved & removed.

Beside that I've got a question:

I can't figure out why [line 557](https://github.com/czproject/git-php/blob/ebc5b3c48fa44dbcbf1ccb7ffc32baca0960efcc/src/GitRepository.php#L557) could be a bad idea. Would you give me a short explanation?