### PR TITLE
getLastCommitId returned null on Windows

### DIFF
--- a/src/GitRepository.php
+++ b/src/GitRepository.php
@@ -377,14 +377,14 @@
 
 		/**
 		 * Returns last commit ID on current branch
-		 * `git log --pretty=format:'%H' -n 1`
+		 * `git log --pretty=format:"%H" -n 1`
 		 * @return string|NULL
 		 * @throws GitException
 		 */
 		public function getLastCommitId()
 		{
 			$this->begin();
-			$lastLine = exec('git log --pretty=format:\'%H\' -n 1 2>&1');
+			$lastLine = exec('git log --pretty=format:"%H" -n 1 2>&1');
 			$this->end();
 			if (preg_match('/^[0-9a-f]{40}$/i', $lastLine)) {
 				return $lastLine;


### PR DESCRIPTION
getLastCommitId returned null on Windows because it added the single quotes to the result as well.

![chrome_2019-01-25_00-33-58](https://user-images.githubusercontent.com/4533867/51715633-dc22be80-2039-11e9-917c-1e8667788c44.png)
