### PR TITLE
Change PHP keywords to comply with PSR2

### DIFF
--- a/tests/GitPhp/bootstrap.php
+++ b/tests/GitPhp/bootstrap.php
@@ -3,7 +3,7 @@ require __DIR__ . '/../../vendor/nette/tester/Tester/bootstrap.php';
 
 // create temporary directory
 define('TEMP_DIR', __DIR__ . '/../tmp/' . (isset($_SERVER['argv']) ? md5(serialize($_SERVER['argv'])) : getmypid()));
-@mkdir(TEMP_DIR, 0777, TRUE);
+@mkdir(TEMP_DIR, 0777, true);
 Tester\Helpers::purge(TEMP_DIR);
 
 


### PR DESCRIPTION
Hi, I've changed a PHP keyword to comply with [this standard](https://www.php-fig.org/psr/psr-2/#25-keywords-and-truefalsenull) in PSR2. It's admittedly a small fix but I hope it helps!