### PR TITLE
Added getAllCommits method

### DIFF
--- a/src/GitRepository.php
+++ b/src/GitRepository.php
@@ -959,4 +959,24 @@
 			return $data;
 		}
 
+		/**
+		 * @param string $branch
+		 * @param bool $count
+		 * @return IGit|NULL|string|string[]
+		 * @throws GitException
+		 */
+		function getAllCommits($branch = 'HEAD', $count = false)
+		{
+			if ($count) {
+				$this->begin();
+				$commitCount = exec('git rev-list --count ' . $branch . ' 2>&1');
+				$this->end();
+
+				return $commitCount;
+			}
+
+			return $this->extractFromCommand('git rev-list ' . $branch, function($value) {
+				return trim(substr($value, 1));
+			});
+		}
 	}

--- a/src/GitRepository.php
+++ b/src/GitRepository.php
@@ -965,7 +965,7 @@
 		 * @return IGit|NULL|string|string[]
 		 * @throws GitException
 		 */
-		function getAllCommits($branch = 'HEAD', $count = false)
+		function getAllCommits($branch = 'HEAD', $count = FALSE)
 		{
 			if ($count) {
 				$this->begin();

--- a/src/IGit.php
+++ b/src/IGit.php
@@ -230,6 +230,16 @@
 		 * @return self
 		 */
 		static function cloneRepository($url, $directory = NULL);
+
+
+		/**
+		 * Get all commits from a branch
+		 * @param  string
+		 * @param  boolean
+		 * @return IGit|NULL|string|string[]
+		 * @throws GitException
+		 */
+		function getAllCommits($branch = 'HEAD', $count = false);
 	}
 
 

--- a/src/IGit.php
+++ b/src/IGit.php
@@ -239,7 +239,7 @@
 		 * @return IGit|NULL|string|string[]
 		 * @throws GitException
 		 */
-		function getAllCommits($branch = 'HEAD', $count = false);
+		function getAllCommits($branch = 'HEAD', $count = FALSE);
 	}
 
 


### PR DESCRIPTION
I've added a `getAllCommits` method.
This can be usefull to use for example with `getCommitMessage` or `getCommitData`.
Also the `getAllCommits` can be used for version build number generation.