### PR TITLE
Fixed cloneRepository() error in PHP7.4

### DIFF
--- a/src/GitRepository.php
+++ b/src/GitRepository.php
@@ -771,8 +771,8 @@
 			}
 
 			$descriptorspec = array(
-				0 => array('pipe', 'r'), // stdout
-				1 => array('pipe', 'w'), // stdin
+				0 => array('pipe', 'r'), // stdin
+				1 => array('pipe', 'w'), // stdout
 				2 => array('pipe', 'w'), // stderr
 			);
 
@@ -797,7 +797,7 @@
 			while (TRUE)
 			{
 				// Read standard output
-				$output = fgets($pipes[0], 1024);
+				$output = fgets($pipes[1], 1024);
 
 				if ($output)
 				{
@@ -813,7 +813,7 @@
 				}
 
 				// We are done
-				if ((feof($pipes[0]) OR $output === FALSE) AND (feof($pipes[2]) OR $output_err === FALSE))
+				if ((feof($pipes[1]) OR $output === FALSE) AND (feof($pipes[2]) OR $output_err === FALSE))
 				{
 					break;
 				}


### PR DESCRIPTION
This bug existed before PHP7.4

```
read of 8192 bytes failed with errno=9 Bad file descriptor
```
https://bugs.php.net/bug.php?id=78482