### PR TITLE
Get remote last commit Id

### DIFF
--- a/src/GitRepository.php
+++ b/src/GitRepository.php
@@ -620,4 +620,17 @@
 
 			return $result;
 		}
+		/**
+		 * Returns last commit ID on remote 
+		 * `git log origin master --pretty=format:"%H" -n 1`
+		 * @return CommitId
+		 * @throws GitException
+		 */
+		
+		public function getLastRemoteCommitId($remote)
+		{
+			$result = $this->run('log', $remote, '--pretty=format:%H', '-n', '1');
+			$lastLine = $result->getOutputLastLine();
+			return new CommitId((string) $lastLine);
+		}
 	}


### PR DESCRIPTION
Function with the purpose of obtain remote last commit id that can be used whit getLastCommitID to verify that the local repository is up to date with the latest commit