### PR TITLE
Fix syntax error in removeRemote command

### DIFF
--- a/src/GitRepository.php
+++ b/src/GitRepository.php
@@ -540,7 +540,7 @@
 		 */
 		public function removeRemote($name)
 		{
-			$this->run('remote', 'remove', '--end-of-options', $name);
+			$this->run('remote', 'remove', $name);
 			return $this;
 		}
 


### PR DESCRIPTION
This function was not working. The `git remote remove` command does not allow any options, so adding `--end-of-options` breaks the syntax.